### PR TITLE
Create outlink for flake builds

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -20,4 +20,4 @@ jobs:
           restore-prefixes-first-match: nix-${{ runner.os }}-
           gc-max-store-size: 1G
       - name: Build all NixOS configurations
-        run: "nix flake show --json | jq -r '.nixosConfigurations | keys[]' | xargs -I {} nix build --no-link .#nixosConfigurations.{}.config.system.build.toplevel"
+        run: "nix flake show --json | jq -r '.nixosConfigurations | keys[]' | xargs -I {} nix build --out-link result-{} .#nixosConfigurations.{}.config.system.build.toplevel"


### PR DESCRIPTION
This prevents the builds in the nix store from being cleared