### PR TITLE
Pin cuda version for frigate

### DIFF
--- a/system/catalyst/containers/homeassistant.nix
+++ b/system/catalyst/containers/homeassistant.nix
@@ -168,7 +168,7 @@ in
 
     frigate = {
       enable = true;
-      package = pkgs.pkgsCuda.frigate;
+      package = pkgs.cudaPackages_12.pkgs.frigate;
       checkConfig = false;
       hostname = "frigate.emmberkat.com";
       vaapiDriver = "nvidia";


### PR DESCRIPTION
onnxruntime needs 12.x currently
