### PR TITLE
Remove frigate overlay from flake.nix

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -74,11 +74,6 @@
             {
               nixpkgs.overlays = [
                 nix-minecraft.overlay
-                (self: super: {
-                  frigate = super.frigate.overrideAttrs (old: {
-                    patches = (old.patches or [ ]) ++ [ ./frigate.patch ];
-                  });
-                })
               ];
             }
             ./system/catalyst


### PR DESCRIPTION
Removed custom overlay for frigate in flake.nix.