### PR TITLE
Remove minecraft.nix from default.nix

### DIFF
--- a/system/catalyst/containers/default.nix
+++ b/system/catalyst/containers/default.nix
@@ -5,7 +5,6 @@
     ./immich.nix
     ./jellyfin.nix
     ./llm.nix
-    ./minecraft.nix
     ./unifi.nix
   ];
 


### PR DESCRIPTION
Removed minecraft.nix from the container configuration.